### PR TITLE
chore: hide trigger ids from view

### DIFF
--- a/src/renderer/src/components/trigger/Trigger.tsx
+++ b/src/renderer/src/components/trigger/Trigger.tsx
@@ -42,7 +42,7 @@ export default function Trigger(): ReactElement {
           justifyContent: 'space-between',
         }}
       >
-        <Typography level="h2">{`Trigger #${triggerId}`}</Typography>
+        <Typography level="h2">Trigger</Typography>
       </Box>
       <Typography sx={{}} level="title-md">
         Name

--- a/src/renderer/src/components/trigger/TriggerTable.tsx
+++ b/src/renderer/src/components/trigger/TriggerTable.tsx
@@ -103,12 +103,12 @@ export default function TriggerTable(): ReactElement {
                 </td>
                 <td>
                   <Typography level="body-xs">
-                    {_.truncate(row.name, {length: 25})}
+                    {_.truncate(row.name, { length: 25 })}
                   </Typography>
                 </td>
                 <td>
                   <Typography level="body-xs">
-                    {_.truncate(row.description,{length: 25})}
+                    {_.truncate(row.description, { length: 25 })}
                   </Typography>
                 </td>
                 <td>

--- a/src/renderer/src/components/trigger/TriggerTable.tsx
+++ b/src/renderer/src/components/trigger/TriggerTable.tsx
@@ -3,7 +3,6 @@ import { ReactElement } from 'react';
 import { useSelector } from 'react-redux';
 import { Link as RouterLink } from 'react-router-dom';
 
-import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 // icons
 import Box from '@mui/joy/Box';
 import Checkbox from '@mui/joy/Checkbox';
@@ -19,7 +18,7 @@ import RowMenu from '../common/RowMenu';
 import { deleteTrigger, selectTriggers } from './TriggersSlice';
 
 export default function TriggerTable(): ReactElement {
-  const [order, setOrder] = React.useState<Order>('desc');
+  const [order] = React.useState<Order>('desc');
   const [selected, setSelected] = React.useState<readonly string[]>([]);
 
   const triggers = useSelector(selectTriggers);
@@ -77,25 +76,6 @@ export default function TriggerTable(): ReactElement {
                   sx={{ verticalAlign: 'text-bottom' }}
                 />
               </th>
-              {/*      <th style={{ width: 20, padding: '12px 6px' }}>
-                <Link
-                  underline="none"
-                  color="primary"
-                  component="button"
-                  onClick={() => setOrder(order === 'asc' ? 'desc' : 'asc')}
-                  fontWeight="lg"
-                  endDecorator={<ArrowDropDownIcon />}
-                  sx={{
-                    '& svg': {
-                      transition: '0.2s',
-                      transform:
-                        order === 'desc' ? 'rotate(0deg)' : 'rotate(180deg)',
-                    },
-                  }}
-                >
-                  ID
-                </Link>
-              </th> */}
               <th style={{ width: 100, padding: '12px 6px' }}>Name</th>
               <th style={{ width: 100, padding: '12px 6px' }}>Description</th>
               <th style={{ width: 100, padding: '12px 6px' }}>Evaluator</th>
@@ -121,17 +101,14 @@ export default function TriggerTable(): ReactElement {
                     sx={{ verticalAlign: 'text-bottom' }}
                   />
                 </td>
-                {/*  <td>
-                  <Typography level="body-xs">{row.id}</Typography>
-                </td> */}
                 <td>
                   <Typography level="body-xs">
-                    {_.truncate(row.name, 25)}
+                    {_.truncate(row.name, {length: 25})}
                   </Typography>
                 </td>
                 <td>
                   <Typography level="body-xs">
-                    {_.truncate(row.description, 25)}
+                    {_.truncate(row.description,{length: 25})}
                   </Typography>
                 </td>
                 <td>

--- a/src/renderer/src/components/trigger/TriggerTable.tsx
+++ b/src/renderer/src/components/trigger/TriggerTable.tsx
@@ -77,7 +77,7 @@ export default function TriggerTable(): ReactElement {
                   sx={{ verticalAlign: 'text-bottom' }}
                 />
               </th>
-              <th style={{ width: 20, padding: '12px 6px' }}>
+              {/*      <th style={{ width: 20, padding: '12px 6px' }}>
                 <Link
                   underline="none"
                   color="primary"
@@ -95,7 +95,7 @@ export default function TriggerTable(): ReactElement {
                 >
                   ID
                 </Link>
-              </th>
+              </th> */}
               <th style={{ width: 100, padding: '12px 6px' }}>Name</th>
               <th style={{ width: 100, padding: '12px 6px' }}>Description</th>
               <th style={{ width: 100, padding: '12px 6px' }}>Evaluator</th>
@@ -121,9 +121,9 @@ export default function TriggerTable(): ReactElement {
                     sx={{ verticalAlign: 'text-bottom' }}
                   />
                 </td>
-                <td>
+                {/*  <td>
                   <Typography level="body-xs">{row.id}</Typography>
-                </td>
+                </td> */}
                 <td>
                   <Typography level="body-xs">
                     {_.truncate(row.name, 25)}


### PR DESCRIPTION
hide the trigger ids from the user interface

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated the trigger display to show a consistent title ("Trigger") instead of a dynamic one.
  - Streamlined the trigger table by removing the ID column, resulting in a cleaner presentation of trigger details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->